### PR TITLE
homogénéisation de la page a propos en centrant les remerciments

### DIFF
--- a/a-propos/index.html
+++ b/a-propos/index.html
@@ -60,6 +60,7 @@
 <div class="remerciements">
 	<h2 id="images-cauet-burger"><center>Remerciements</center></h2>
 <hr class="hr-a-propos" align="center">
+<center>
 	<ul style="list-style-type:none;">
 		<li><a href="https://www.youtube.com/channel/UCHgCk2vIEoeMHOd_lFVRevQ"><b>Fripouz</b></a> : Création de la lutte, du Discord et de la chaîne YouTube, organisateur de la rencontre IRL.</li>
 		<li><a href="https://www.konbini.com/"><b>Konbini</b></a> : Médiatisation de la lutte, réalisation du reportage sur la lutte.</li>
@@ -71,6 +72,7 @@
 		<li><a href="https://myburger.fr/"><b>MyBurger</b></a> : photographies du Cauet Burger de 2006.</li>
 		<li><a href="https://potinsmedias.wordpress.com/"><b>PotinsMédias</b></a> : photographies des Cauet Burger de 2022.</li>
 	</ul>
+	</center>
 				<div class="container">
 		<div class="grid">
 			<center><h4 class="grid-title">Collage des affiches</h4></center>


### PR DESCRIPTION
Hello

Dans la page "à propos", les remerciements ne sont pas centrés, ce qui rend la page non homogène avec la liste des collages d'affiches en dessous, qui eux sont centrés.

Ce commit centre donc les remerciements.